### PR TITLE
refactor: bus send with safe and fix typos

### DIFF
--- a/examples/sfu/mod.rs
+++ b/examples/sfu/mod.rs
@@ -134,7 +134,7 @@ impl SfuWorker {
         );
         match task {
             Ok(task) => {
-                log::info!("Whip enpoint created {}", task.ice_ufrag);
+                log::info!("Whip endpoint created {}", task.ice_ufrag);
                 let index = self.whip_group.add_task(task.task);
                 self.shared_udp
                     .add_ufrag(task.ice_ufrag, TaskId::Whip(index));
@@ -181,7 +181,7 @@ impl SfuWorker {
         );
         match task {
             Ok(task) => {
-                log::info!("Whep enpoint created {}", task.ice_ufrag);
+                log::info!("Whep endpoint created {}", task.ice_ufrag);
                 let index = self.whep_group.add_task(task.task);
                 self.shared_udp
                     .add_ufrag(task.ice_ufrag, TaskId::Whep(index));

--- a/examples/udp_echo_client.rs
+++ b/examples/udp_echo_client.rs
@@ -45,7 +45,7 @@ impl<const FAKE_TYPE: u16> EchoTask<FAKE_TYPE> {
                 [127, 0, 0, 1],
                 0,
             )))))
-            .print_err2("should not happend");
+            .print_err2("should not hapended");
         Self {
             count: 0,
             cfg,

--- a/src/bus/leg.rs
+++ b/src/bus/leg.rs
@@ -34,6 +34,23 @@ impl<ChannelId, MSG, const STATIC_SIZE: usize> Clone for BusLegSender<ChannelId,
 }
 
 impl<ChannelId, MSG, const STATIC_SIZE: usize> BusLegSender<ChannelId, MSG, STATIC_SIZE> {
+    /// Sends a message through the bus leg with safe, if stack full, it will append to heap.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - The source of the bus event.
+    /// * `msg` - The message to be sent.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(len)` if the message is successfully sent, where `len` is the new length of the queue.
+    /// Returns `Err(ChannelFull)` if the queue is already full and the message cannot be sent.
+    pub fn send_safe(&self, source: BusEventSource<ChannelId>, msg: MSG) -> usize {
+        let mut queue = self.queue.lock();
+        queue.push_back_safe((source, msg));
+        queue.len()
+    }
+
     /// Sends a message through the bus leg.
     ///
     /// # Arguments

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -7,7 +7,7 @@ use crate::{
     worker::{self, WorkerControlIn, WorkerControlOut, WorkerInner, WorkerStats},
 };
 
-const DEFAULT_STACK_SIZE: usize = 16 * 1024 * 1024;
+const DEFAULT_STACK_SIZE: usize = 12 * 1024 * 1024;
 
 struct WorkerContainer {
     _join: std::thread::JoinHandle<()>,
@@ -72,17 +72,7 @@ impl<
         let join = std::thread::Builder::new()
             .stack_size(stack_size)
             .spawn(move || {
-                let mut worker = worker::Worker::<
-                    ExtIn,
-                    ExtOut,
-                    ChannelId,
-                    Event,
-                    Inner,
-                    ICfg,
-                    SCfg,
-                    B,
-                    INNER_BUS_STACK,
-                >::new(
+                let mut worker = worker::Worker::<_, _, _, _, _, _, _, B, INNER_BUS_STACK>::new(
                     Inner::build(worker_in.leg_index() as u16, cfg),
                     worker_inner,
                     worker_out,

--- a/src/task/group.rs
+++ b/src/task/group.rs
@@ -124,7 +124,7 @@ impl<
     }
 
     /// Retrieves the output from the last processed task input event.
-    /// In SAN/IO we ussually have some output when we receive an input event.
+    /// In SAN/IO we usually have some output when we receive an input event.
     pub fn pop_last_input<'a>(
         &mut self,
         now: Instant,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -90,7 +90,7 @@ pub(crate) struct Worker<
     backend: B,
     worker_out: BusWorker<u16, WorkerControlOut<ExtOut>, 16>,
     worker_in: BusWorker<u16, WorkerControlIn<ExtIn, SCfg>, 16>,
-    network_buffer: [u8; 1500],
+    network_buffer: [u8; 8096],
     _tmp: std::marker::PhantomData<(Owner, ICfg)>,
 }
 
@@ -119,7 +119,7 @@ impl<
             backend: Default::default(),
             worker_out,
             worker_in,
-            network_buffer: [0; 1500],
+            network_buffer: [0; 8096],
             _tmp: Default::default(),
         }
     }
@@ -147,12 +147,9 @@ impl<
                         tasks: self.inner.tasks(),
                         ultilization: 0, //TODO measure this thread ultilization
                     };
-                    if let Err(e) = self
-                        .worker_out
+                    self.worker_out
                         .send(0, true, WorkerControlOut::Stats(stats))
-                    {
-                        log::error!("Failed to send stats: {:?}", e);
-                    }
+                        .expect("Should send success with safe flag");
                 }
             }
         }


### PR DESCRIPTION
This PR refactor bus with send_safe function