### PR TITLE
add tcp protocol

### DIFF
--- a/examples/sfu/mod.rs
+++ b/examples/sfu/mod.rs
@@ -353,6 +353,7 @@ impl WorkerInner<ExtIn, ExtOut, ChannelId, SfuEvent, ICfg, SCfg> for SfuWorker {
                         _ => None,
                     }
                 }
+                _ => None,
             },
             WorkerInnerInput::Ext(_ext) => {
                 self.last_input = None;

--- a/examples/sfu/whep.rs
+++ b/examples/sfu/whep.rs
@@ -200,6 +200,18 @@ impl Task<ChannelId, SfuEvent> for WhepTask {
                 NetIncoming::UdpListenResult { .. } => {
                     panic!("Unexpected UdpListenResult");
                 }
+                NetIncoming::TcpListenResult { .. } => {
+                    panic!("Unexpected TcpListeneResult");
+                }
+                NetIncoming::TcpPacket { .. } => {
+                    panic!("Unexpected TcpPacket");
+                }
+                NetIncoming::TcpOnConnected { .. } => {
+                    panic!("Unexpected TcpOnConnected");
+                }
+                NetIncoming::TcpOnDisconnected { .. } => {
+                    panic!("Unexpected TcpOnDisconnected");
+                }
             },
             TaskInput::Bus(channel, event) => match event {
                 SfuEvent::RequestKeyFrame(_kind) => {

--- a/examples/sfu/whip.rs
+++ b/examples/sfu/whip.rs
@@ -188,6 +188,18 @@ impl Task<ChannelId, SfuEvent> for WhipTask {
                 NetIncoming::UdpListenResult { .. } => {
                     panic!("Unexpected UdpListenResult");
                 }
+                NetIncoming::TcpListenResult { .. } => {
+                    panic!("Unexpected TcpListeneResult");
+                }
+                NetIncoming::TcpPacket { .. } => {
+                    panic!("Unexpected TcpPacket");
+                }
+                NetIncoming::TcpOnConnected { .. } => {
+                    panic!("Unexpected TcpOnConnected");
+                }
+                NetIncoming::TcpOnDisconnected { .. } => {
+                    panic!("Unexpected TcpOnDisconnected");
+                }
             },
             TaskInput::Bus(channel, event) => match event {
                 SfuEvent::RequestKeyFrame(kind) => {

--- a/examples/tcp_echo_server.rs
+++ b/examples/tcp_echo_server.rs
@@ -72,7 +72,7 @@ impl WorkerInner<ExtIn, ExtOut, ChannelId, Event, ICfg, SCfg> for EchoWorker {
             WorkerInnerInput::Task(
                 _owner,
                 TaskInput::Net(NetIncoming::TcpOnConnected {
-                    local_addr,
+                    local_addr: _,
                     remote_addr,
                 }),
             ) => {
@@ -82,7 +82,7 @@ impl WorkerInner<ExtIn, ExtOut, ChannelId, Event, ICfg, SCfg> for EchoWorker {
             WorkerInnerInput::Task(
                 _owner,
                 TaskInput::Net(NetIncoming::TcpOnDisconnected {
-                    local_addr,
+                    local_addr: _,
                     remote_addr,
                 }),
             ) => {

--- a/examples/tcp_echo_server.rs
+++ b/examples/tcp_echo_server.rs
@@ -1,0 +1,128 @@
+use std::{collections::VecDeque, net::SocketAddr, time::Duration};
+
+use sans_io_runtime::{
+    backend::MioBackend, Buffer, Controller, NetIncoming, NetOutgoing, Owner, TaskInput,
+    TaskOutput, WorkerInner, WorkerInnerInput, WorkerInnerOutput,
+};
+
+type ExtIn = ();
+type ExtOut = ();
+type ChannelId = ();
+type Event = ();
+type ICfg = EchoWorkerCfg;
+type SCfg = ();
+
+struct EchoWorkerCfg {
+    bind: SocketAddr,
+}
+
+enum EchoWorkerInQueue {
+    TcpListener(SocketAddr),
+}
+
+struct EchoWorker {
+    worker: u16,
+    output: VecDeque<EchoWorkerInQueue>,
+}
+
+impl WorkerInner<ExtIn, ExtOut, ChannelId, Event, ICfg, SCfg> for EchoWorker {
+    fn build(worker: u16, cfg: EchoWorkerCfg) -> Self {
+        log::info!("Create new echo task in addr {}", cfg.bind);
+        Self {
+            worker,
+            output: VecDeque::from([EchoWorkerInQueue::TcpListener(cfg.bind)]),
+        }
+    }
+
+    fn worker_index(&self) -> u16 {
+        self.worker
+    }
+
+    fn tasks(&self) -> usize {
+        1
+    }
+
+    fn spawn(&mut self, _now: std::time::Instant, _cfg: SCfg) {}
+
+    fn on_input_tick<'a>(
+        &mut self,
+        _now: std::time::Instant,
+    ) -> Option<sans_io_runtime::WorkerInnerOutput<'a, ExtOut, ChannelId, Event, SCfg>> {
+        match self.output.pop_front()? {
+            EchoWorkerInQueue::TcpListener(bind) => Some(WorkerInnerOutput::Task(
+                Owner::worker(self.worker),
+                TaskOutput::Net(NetOutgoing::TcpListen(bind)),
+            )),
+        }
+    }
+
+    fn on_input_event<'a>(
+        &mut self,
+        _now: std::time::Instant,
+        event: sans_io_runtime::WorkerInnerInput<'a, ExtIn, ChannelId, Event>,
+    ) -> Option<WorkerInnerOutput<'a, ExtOut, ChannelId, Event, SCfg>> {
+        match event {
+            WorkerInnerInput::Task(
+                _owner,
+                TaskInput::Net(NetIncoming::TcpListenResult { bind, result }),
+            ) => {
+                log::info!("TcpListen Result: {} {:?}", bind, result);
+                None
+            }
+            WorkerInnerInput::Task(
+                _owner,
+                TaskInput::Net(NetIncoming::TcpOnConnected {
+                    local_addr,
+                    remote_addr,
+                }),
+            ) => {
+                log::info!("Client {} is connected", remote_addr);
+                None
+            }
+            WorkerInnerInput::Task(
+                _owner,
+                TaskInput::Net(NetIncoming::TcpOnDisconnected {
+                    local_addr,
+                    remote_addr,
+                }),
+            ) => {
+                log::info!("Client {} is disconnected", remote_addr);
+                None
+            }
+            WorkerInnerInput::Task(
+                _owner,
+                TaskInput::Net(NetIncoming::TcpPacket { from, to, data }),
+            ) => Some(WorkerInnerOutput::Task(
+                Owner::worker(self.worker),
+                TaskOutput::Net(NetOutgoing::TcpPacket {
+                    from: to,
+                    to: from,
+                    data: Buffer::Vec(data.to_vec()),
+                }),
+            )),
+            _ => None,
+        }
+    }
+
+    fn pop_last_input<'a>(
+        &mut self,
+        _now: std::time::Instant,
+    ) -> Option<WorkerInnerOutput<'a, ExtOut, ChannelId, Event, SCfg>> {
+        None
+    }
+}
+
+fn main() {
+    env_logger::init();
+    let mut controller = Controller::<ExtIn, ExtOut, SCfg, ChannelId, Event, 1024>::default();
+    controller.add_worker::<_, EchoWorker, MioBackend<16, 1024>>(
+        EchoWorkerCfg {
+            bind: SocketAddr::from(([127, 0, 0, 1], 10001)),
+        },
+        None,
+    );
+    loop {
+        controller.process();
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -19,6 +19,23 @@ pub enum BackendIncoming {
         to: SocketAddr,
         len: usize,
     },
+    TcpListenResult {
+        bind: SocketAddr,
+        result: Result<SocketAddr, std::io::Error>,
+    },
+    TcpPacket {
+        from: SocketAddr,
+        to: SocketAddr,
+        len: usize,
+    },
+    TcpOnConnected {
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+    },
+    TcpOnDisconnected {
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+    },
 }
 
 pub trait Backend: Default + BackendOwner {

--- a/src/backend/mio.rs
+++ b/src/backend/mio.rs
@@ -29,6 +29,7 @@
 //!         BackendIncoming::UdpListenResult { bind, result } => {
 //!             // Handle UDP listen result
 //!         }
+//!         _ => { }
 //!     }
 //! }
 //!
@@ -74,7 +75,7 @@ fn addr_seed_to_token(addr: SocketAddr, seed: u16) -> Token {
 }
 
 fn reserve_seed_addr_from_token(token: Token) -> (u16, Token) {
-    let port: u16 = 0 | (token.0 as u16);
+    let port: u16 = token.0 as u16;
     let seed = ((token.0) >> 16) as u16;
     (seed, Token(port as usize))
 }
@@ -200,7 +201,7 @@ impl<const SOCKET_LIMIT: usize, const STACK_QUEUE_SIZE: usize>
                             listener.seed,
                             TcpStreamContainer {
                                 stream: conn,
-                                addr: addr,
+                                addr,
                                 owner: listener.owner,
                             },
                         );
@@ -225,7 +226,7 @@ impl<const SOCKET_LIMIT: usize, const STACK_QUEUE_SIZE: usize>
                                     if n == 0 {
                                         self.output.push_back_safe(InQueue::TcpOnDisconnected {
                                             owner: conn.owner,
-                                            listener_token: listener_token,
+                                            listener_token,
                                             seed,
                                         });
                                     } else {

--- a/src/backend/mio.rs
+++ b/src/backend/mio.rs
@@ -113,7 +113,7 @@ impl TcpListenerContainer<Owner> {
                 self.conn_addrs.insert(addr, self.seed);
                 self.next_seed();
 
-                return Some(addr);
+                Some(addr)
             }
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => None,
             Err(e) => {


### PR DESCRIPTION
## What
This PR adds TCP protocol for the MIO backend

## Change
The significant change is file **src/backend/mio.rs**, which adds logic for TCP protocol. 
- I created `TcpListenerContainer` to keep the TCP listener. If one connection is connected to the TCP listener, it will save `TcpStreamContainer` inside it.
- Because each connection needs to register with the poll as a unique event source, I added an `addr_seed_to_token` function to create its unique token. That function will generate a token by using the listener port and its connection seed (incrementally when the listener has a new connection).

## How to test
- exec `RUST_MIN_STACK=6400000 RUST_LOG=info cargo run --example tcp_echo_server` command to start the TCP server.
- using the `telnet` command to connect to that TCP server as a client.

## QA
- Why will the `event_buffer` pop in the next tick instead of instantly after it is processed?
